### PR TITLE
Add Slack unfurl metadata for dashboards

### DIFF
--- a/superset/embedded/view.py
+++ b/superset/embedded/view.py
@@ -55,6 +55,7 @@ class EmbeddedView(BaseSupersetView):
             abort(404)
 
         assert embedded is not None
+        dashboard = embedded.dashboard
 
         # validate request referrer in allowed domains
         is_referrer_allowed = not embedded.allowed_domains
@@ -89,6 +90,8 @@ class EmbeddedView(BaseSupersetView):
         return self.render_template(
             "superset/spa.html",
             entry="embedded",
+            title=dashboard.dashboard_title,
+            dashboard_description=dashboard.description,
             bootstrap_data=json.dumps(
                 bootstrap_data, default=json.pessimistic_json_iso_dttm_ser
             ),

--- a/superset/templates/superset/spa.html
+++ b/superset/templates/superset/spa.html
@@ -18,6 +18,15 @@
 #}
 {% extends "superset/basic.html" %}
 
+{% block head_meta %}
+  {% if title %}<meta property="og:title" content="{{ title }}" />{% endif %}
+  {% if dashboard_description %}
+    <meta property="og:description" content="{{ dashboard_description }}" />
+  {% endif %}
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="{{ request.url }}" />
+{% endblock %}
+
 {% block navbar %}
 {% endblock %}
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -820,6 +820,7 @@ class Superset(BaseSupersetView):
             "superset/spa.html",
             entry="spa",
             title=dashboard.dashboard_title,  # dashboard title is always visible
+            dashboard_description=dashboard.description,
             bootstrap_data=json.dumps(
                 {
                     "user": bootstrap_user_data(g.user, include_perms=True),


### PR DESCRIPTION
## Summary
- include Open Graph metadata in SPA template for Slack unfurling
- supply dashboard title and description to dashboard and embedded views

